### PR TITLE
Expose SA tuning parameters and thread last-moved vars to hooks

### DIFF
--- a/benchmarks/bunker-eca/bunker_speed_hook.h
+++ b/benchmarks/bunker-eca/bunker_speed_hook.h
@@ -21,9 +21,10 @@ class BunkerSpeedHook : public InnerSolverHook {
 public:
     FloatIntensifyHook float_hook;
 
-    void solve(Model& model, ViolationManager& vm) override {
+    void solve(Model& model, ViolationManager& vm,
+               const std::vector<int32_t>& last_changed_vars = {}) override {
         if (!inst_) {
-            float_hook.solve(model, vm);
+            float_hook.solve(model, vm, last_changed_vars);
             return;
         }
 
@@ -75,7 +76,7 @@ public:
             delta_evaluate(model, changed);
         }
 
-        float_hook.solve(model, vm);
+        float_hook.solve(model, vm, last_changed_vars);
     }
 
     void set_model(const BunkerECAModel* bec_model, const Instance* inst) {

--- a/benchmarks/nuclear-outage/nuclear_hook.h
+++ b/benchmarks/nuclear-outage/nuclear_hook.h
@@ -32,7 +32,8 @@ public:
     NuclearDispatchHook(const NuclearInstance& inst_, const NuclearModel& nm_)
         : inst(inst_), nm(nm_) {}
 
-    void solve(Model& model, ViolationManager& /*vm*/) override {
+    void solve(Model& model, ViolationManager& /*vm*/,
+               const std::vector<int32_t>& /*last_changed_vars*/ = {}) override {
         // 1. Read current outage start values (convert var handles to var IDs)
         std::vector<int> starts(inst.n_outages);
         for (int o = 0; o < inst.n_outages; ++o) {

--- a/benchmarks/pharma-glsp/glsp_hook.h
+++ b/benchmarks/pharma-glsp/glsp_hook.h
@@ -30,7 +30,8 @@ public:
             for (auto h : lot_handles[j]) lot_vars_[j].push_back(handle_to_vid(h));
     }
 
-    void solve(Model& model, ViolationManager& vm) override {
+    void solve(Model& model, ViolationManager& vm,
+               const std::vector<int32_t>& /*last_changed_vars*/ = {}) override {
         int J = inst_.n_products;
         int T = inst_.n_macro;
         std::set<int32_t> changed;

--- a/include/cbls/inner_solver.h
+++ b/include/cbls/inner_solver.h
@@ -2,6 +2,8 @@
 
 #include "model.h"
 #include "violation.h"
+#include <vector>
+#include <cstdint>
 
 namespace cbls {
 
@@ -11,7 +13,9 @@ public:
 
     // Called with mutable model + violation manager.
     // Hook mutates model directly (var values + delta_evaluate).
-    virtual void solve(Model& model, ViolationManager& vm) = 0;
+    // last_changed_vars: var IDs changed in the last accepted SA move (empty on reheat).
+    virtual void solve(Model& model, ViolationManager& vm,
+                       const std::vector<int32_t>& last_changed_vars = {}) = 0;
 };
 
 // Generic Float intensification: coordinate-descent sweeps over all Float vars
@@ -23,7 +27,8 @@ public:
     int max_line_search_steps = 5;
     int max_multi_var_constraints = 5;
 
-    void solve(Model& model, ViolationManager& vm) override;
+    void solve(Model& model, ViolationManager& vm,
+               const std::vector<int32_t>& last_changed_vars = {}) override;
 };
 
 }  // namespace cbls

--- a/include/cbls/search.h
+++ b/include/cbls/search.h
@@ -10,6 +10,13 @@
 
 namespace cbls {
 
+struct SearchConfig {
+    double cooling_rate = 0.9999;
+    int reheat_interval = 5000;
+    int hook_frequency = 10;
+    double fj_time_fraction = 0.2;
+};
+
 struct SearchResult {
     double objective = std::numeric_limits<double>::infinity();
     bool feasible = false;
@@ -46,6 +53,7 @@ SearchResult solve(Model& model, double time_limit = 10.0,
                    InnerSolverHook* hook = nullptr,
                    LNS* lns = nullptr,
                    int lns_interval = 3,
-                   SolveCallback* callback = nullptr);
+                   SolveCallback* callback = nullptr,
+                   const SearchConfig& config = {});
 
 }  // namespace cbls

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -311,6 +311,14 @@ NB_MODULE(_cbls_core, m) {
         .def_rw("max_line_search_steps", &FloatIntensifyHook::max_line_search_steps)
         .def_rw("max_multi_var_constraints", &FloatIntensifyHook::max_multi_var_constraints);
 
+    // SearchConfig
+    nb::class_<SearchConfig>(m, "SearchConfig")
+        .def(nb::init<>())
+        .def_rw("cooling_rate", &SearchConfig::cooling_rate)
+        .def_rw("reheat_interval", &SearchConfig::reheat_interval)
+        .def_rw("hook_frequency", &SearchConfig::hook_frequency)
+        .def_rw("fj_time_fraction", &SearchConfig::fj_time_fraction);
+
     // SolveProgress
     nb::class_<SolveProgress>(m, "SolveProgress")
         .def(nb::init<>())
@@ -336,7 +344,8 @@ NB_MODULE(_cbls_core, m) {
           nb::arg("hook") = nullptr,
           nb::arg("lns") = nullptr,
           nb::arg("lns_interval") = 3,
-          nb::arg("callback") = nullptr);
+          nb::arg("callback") = nullptr,
+          nb::arg("config") = SearchConfig{});
     m.def("initialize_random", &initialize_random);
     m.def("fj_nl_initialize", &fj_nl_initialize,
           nb::arg("model"), nb::arg("vm"), nb::arg("max_iterations") = 10000,

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -22,6 +22,10 @@ Options:
   --lns FRACTION        Enable LNS with destroy fraction, e.g. 0.3
   --lns-interval INT    LNS fires every N reheats (default: 3)
   --intensify           Enable float intensification hook
+  --cooling-rate FLOAT  SA cooling rate (default: 0.9999)
+  --reheat-interval INT SA reheat interval in iterations (default: 5000)
+  --hook-frequency INT  Run hook every N discrete acceptances (default: 10)
+  --fj-time-fraction F  Fraction of time limit for FJ init (default: 0.2)
   --format human|jsonl  Output format (default: human)
   --quiet               Suppress progress, print only final result
   --help                Show this help message
@@ -37,6 +41,7 @@ int main(int argc, char* argv[]) {
     bool use_intensify = false;
     double lns_fraction = 0.0;
     int lns_interval = 3;
+    SearchConfig config;
     std::string format = "human";
     bool quiet = false;
 
@@ -60,6 +65,14 @@ int main(int argc, char* argv[]) {
             lns_interval = std::stoi(argv[++i]);
         } else if (arg == "--intensify") {
             use_intensify = true;
+        } else if (arg == "--cooling-rate" && i + 1 < argc) {
+            config.cooling_rate = std::stod(argv[++i]);
+        } else if (arg == "--reheat-interval" && i + 1 < argc) {
+            config.reheat_interval = std::stoi(argv[++i]);
+        } else if (arg == "--hook-frequency" && i + 1 < argc) {
+            config.hook_frequency = std::stoi(argv[++i]);
+        } else if (arg == "--fj-time-fraction" && i + 1 < argc) {
+            config.fj_time_fraction = std::stod(argv[++i]);
         } else if (arg == "--format" && i + 1 < argc) {
             format = argv[++i];
             if (format != "human" && format != "jsonl") {
@@ -112,7 +125,7 @@ int main(int argc, char* argv[]) {
     }
 
     auto result = solve(model, time_limit, seed, use_fj,
-                        hook, lns_ptr, lns_interval, callback);
+                        hook, lns_ptr, lns_interval, callback, config);
 
     if (format == "human") {
         human_fmt.print_result(result, model);

--- a/src/inner_solver.cpp
+++ b/src/inner_solver.cpp
@@ -6,7 +6,8 @@
 
 namespace cbls {
 
-void FloatIntensifyHook::solve(Model& model, ViolationManager& vm) {
+void FloatIntensifyHook::solve(Model& model, ViolationManager& vm,
+                               const std::vector<int32_t>& /*last_changed_vars*/) {
     for (int sweep = 0; sweep < max_sweeps; ++sweep) {
         bool improved = false;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -225,7 +225,7 @@ static SolveProgress make_progress(int64_t iteration, double elapsed,
 
 SearchResult solve(Model& model, double time_limit, uint64_t seed, bool use_fj,
                    InnerSolverHook* hook, LNS* lns, int lns_interval,
-                   SolveCallback* callback) {
+                   SolveCallback* callback, const SearchConfig& config) {
     RNG rng(seed);
     ViolationManager vm(model);
 
@@ -237,8 +237,7 @@ SearchResult solve(Model& model, double time_limit, uint64_t seed, bool use_fj,
     full_evaluate(model);
 
     if (use_fj) {
-        constexpr double fj_time_fraction = 0.2;
-        fj_nl_initialize(model, vm, 5000, &rng, time_limit * fj_time_fraction);
+        fj_nl_initialize(model, vm, 5000, &rng, time_limit * config.fj_time_fraction);
     }
 
     double current_F = vm.augmented_objective();
@@ -251,8 +250,8 @@ SearchResult solve(Model& model, double time_limit, uint64_t seed, bool use_fj,
     }
 
     double temperature = initial_temperature(best_F);
-    double cooling_rate = 0.9999;
-    int reheat_interval = 5000;
+    double cooling_rate = config.cooling_rate;
+    int reheat_interval = config.reheat_interval;
 
     MoveProbabilities move_probs({
         "flip", "int_dec", "int_inc", "int_rand",
@@ -265,7 +264,7 @@ SearchResult solve(Model& model, double time_limit, uint64_t seed, bool use_fj,
     int64_t iteration = 0;
     int reheat_count = 0;
     int64_t discrete_accepts_since_hook = 0;
-    const int64_t hook_frequency = 10;  // run hook every N discrete acceptances
+    const int64_t hook_frequency = config.hook_frequency;
 
     auto last_callback_time = start;
     constexpr double callback_interval_secs = 1.0;
@@ -362,7 +361,7 @@ SearchResult solve(Model& model, double time_limit, uint64_t seed, bool use_fj,
                 }
                 if (has_discrete && ++discrete_accepts_since_hook >= hook_frequency) {
                     discrete_accepts_since_hook = 0;
-                    hook->solve(model, vm);
+                    hook->solve(model, vm, changed);
                     update_best_after_hook(model, vm, best_F, best_feasible_obj, best_state);
                 }
             }


### PR DESCRIPTION
## Summary
- Add `SearchConfig` struct with `cooling_rate`, `reheat_interval`, `hook_frequency`, and `fj_time_fraction` fields, replacing hardcoded SA parameters in `solve()`
- Add `last_changed_vars` parameter to `InnerSolverHook::solve()` so hooks can perform incremental work based on which variables the SA move changed
- Expose new config via CLI flags (`--cooling-rate`, `--reheat-interval`, `--hook-frequency`, `--fj-time-fraction`) and Python bindings

Both changes are backwards-compatible — all existing call sites continue to compile without modification via default arguments. This unblocks benchmark-specific tuning (bunker-eca hook_frequency=50, pharma-glsp slower cooling) and incremental dispatch in nuclear outage.

## Test plan
- [x] 146/146 C++ tests pass after merging latest main
- [x] All benchmark executables (uc-chped, nuclear-outage, bunker-eca, pharma-glsp) build cleanly
- [x] No signature breaks — existing hooks updated to match new API

🤖 Generated with [Claude Code](https://claude.com/claude-code)