### PR TITLE
Optimize nuclear outage dispatch hook (1.5x throughput)

### DIFF
--- a/benchmarks/nuclear-outage/dispatch.h
+++ b/benchmarks/nuclear-outage/dispatch.h
@@ -2,6 +2,7 @@
 
 #include "data.h"
 #include <algorithm>
+#include <cstring>
 #include <numeric>
 #include <vector>
 
@@ -140,6 +141,225 @@ inline double resource_violation_penalty(
 
     return violation * penalty_weight;
 }
+
+// -------------------------------------------------------------------------
+// DispatchEvaluator: allocation-free dispatch + resource penalty evaluation
+// Pre-allocates all scratch buffers; uses flat contiguous availability array;
+// caches merit order; supports delta resource penalty.
+// -------------------------------------------------------------------------
+
+class DispatchEvaluator {
+public:
+    explicit DispatchEvaluator(const NuclearInstance& inst)
+        : inst_(inst),
+          avail_(inst.n_periods * inst.n_units, 1),
+          merit_order_(inst.n_units),
+          site_count_(inst.n_sites, 0),
+          site_outages_(inst.n_sites),
+          outage_site_(inst.n_outages)
+    {
+        // 5c: cache merit order once (fuel costs never change)
+        std::iota(merit_order_.begin(), merit_order_.end(), 0);
+        std::sort(merit_order_.begin(), merit_order_.end(),
+                  [&](int a, int b) { return inst.fuel_cost[a] < inst.fuel_cost[b]; });
+
+        // Pre-compute outage→site mapping
+        for (int o = 0; o < inst.n_outages; ++o) {
+            outage_site_[o] = inst.site[inst.outage_unit[o]];
+        }
+
+        // Build static site→outages grouping (indices only, sorted later by start)
+        for (int o = 0; o < inst.n_outages; ++o) {
+            site_outages_[outage_site_[o]].push_back(o);
+        }
+    }
+
+    /// Compute expected dispatch cost. No heap allocation on the hot path.
+    double expected_cost(const std::vector<int>& outage_starts,
+                         int n_scenarios, int scenario_offset) {
+        int n_sc = std::min(n_scenarios, inst_.n_scenarios - scenario_offset);
+        int P = inst_.n_periods;
+        int U = inst_.n_units;
+
+        // 5b: reset flat avail array with memset (all units online)
+        std::memset(avail_.data(), 1, P * U);
+
+        // Mark outage periods offline
+        for (int o = 0; o < inst_.n_outages; ++o) {
+            int u = inst_.outage_unit[o];
+            int start = outage_starts[o];
+            int end = std::min(start + inst_.outage_duration[o], P);
+            for (int t = start; t < end; ++t) {
+                avail_[t * U + u] = 0;
+            }
+        }
+
+        // Dispatch across scenarios and periods
+        double total_cost = 0.0;
+        for (int s = scenario_offset; s < scenario_offset + n_sc; ++s) {
+            const auto& demand_s = inst_.demand[s];
+            for (int t = 0; t < P; ++t) {
+                total_cost += dispatch_flat(t, demand_s[t]);
+            }
+        }
+
+        return total_cost / n_sc;
+    }
+
+    /// Compute resource violation penalty using pre-allocated scratch.
+    /// If changed_outage >= 0, only rechecks the affected site (5e: delta).
+    double resource_penalty(const std::vector<int>& outage_starts,
+                            double penalty_weight = 1e6,
+                            int changed_outage = -1) {
+        if (changed_outage >= 0) {
+            return delta_resource_penalty(outage_starts, penalty_weight, changed_outage);
+        }
+        return full_resource_penalty(outage_starts, penalty_weight);
+    }
+
+private:
+    const NuclearInstance& inst_;
+
+    // 5b: flat contiguous availability array [period * n_units + unit]
+    std::vector<uint8_t> avail_;
+
+    // 5c: cached merit order (sorted once at construction)
+    std::vector<int> merit_order_;
+
+    // 5a: pre-allocated scratch buffers
+    std::vector<int> site_count_;
+
+    // 5e: static site→outage grouping (outage indices, re-sorted by start on use)
+    std::vector<std::vector<int>> site_outages_;
+    std::vector<int> outage_site_;  // outage → site
+
+    // 5e: cached per-site penalty contributions
+    std::vector<double> site_capacity_penalty_;
+    std::vector<double> site_spacing_penalty_;
+    double total_penalty_ = 0.0;
+    bool penalty_valid_ = false;
+
+    /// Merit-order dispatch on flat avail array. No allocation.
+    double dispatch_flat(int period, double demand) const {
+        double cost = 0.0;
+        double remaining = demand;
+        int U = inst_.n_units;
+        const uint8_t* row = avail_.data() + period * U;
+
+        for (int u : merit_order_) {
+            if (remaining <= 0.0) break;
+            if (!row[u]) continue;
+            double gen = std::min(inst_.capacity[u], remaining);
+            cost += gen * inst_.fuel_cost[u];
+            remaining -= gen;
+        }
+
+        if (remaining > 0.0) {
+            cost += remaining * inst_.penalty_unserved;
+        }
+        return cost;
+    }
+
+    /// Full resource penalty computation (first call or fallback).
+    double full_resource_penalty(const std::vector<int>& outage_starts,
+                                 double penalty_weight) {
+        int n_sites = inst_.n_sites;
+        site_capacity_penalty_.assign(n_sites, 0.0);
+        site_spacing_penalty_.assign(n_sites, 0.0);
+
+        // (1) Max simultaneous outages per site
+        for (int t = 0; t < inst_.n_periods; ++t) {
+            std::fill(site_count_.begin(), site_count_.end(), 0);
+            for (int o = 0; o < inst_.n_outages; ++o) {
+                int start = outage_starts[o];
+                if (t >= start && t < start + inst_.outage_duration[o]) {
+                    site_count_[outage_site_[o]]++;
+                }
+            }
+            for (int s = 0; s < n_sites; ++s) {
+                int excess = site_count_[s] - inst_.max_outages_per_site[s];
+                if (excess > 0) {
+                    site_capacity_penalty_[s] += excess;
+                }
+            }
+        }
+
+        // (2) Min spacing
+        for (int s = 0; s < n_sites; ++s) {
+            auto& outages = site_outages_[s];
+            if (outages.size() < 2) continue;
+            std::sort(outages.begin(), outages.end(),
+                      [&](int a, int b) { return outage_starts[a] < outage_starts[b]; });
+            for (size_t i = 0; i + 1 < outages.size(); ++i) {
+                int o1 = outages[i];
+                int o2 = outages[i + 1];
+                int end1 = outage_starts[o1] + inst_.outage_duration[o1];
+                int gap = outage_starts[o2] - end1;
+                if (gap < inst_.min_spacing_same_site) {
+                    site_spacing_penalty_[s] += (inst_.min_spacing_same_site - gap);
+                }
+            }
+        }
+
+        total_penalty_ = 0.0;
+        for (int s = 0; s < n_sites; ++s) {
+            total_penalty_ += site_capacity_penalty_[s] + site_spacing_penalty_[s];
+        }
+        penalty_valid_ = true;
+        return total_penalty_ * penalty_weight;
+    }
+
+    /// 5e: Delta resource penalty — only recompute site of changed outage.
+    double delta_resource_penalty(const std::vector<int>& outage_starts,
+                                  double penalty_weight,
+                                  int changed_outage) {
+        if (!penalty_valid_) {
+            return full_resource_penalty(outage_starts, penalty_weight);
+        }
+
+        int site = outage_site_[changed_outage];
+
+        // Subtract old site contribution
+        total_penalty_ -= site_capacity_penalty_[site] + site_spacing_penalty_[site];
+
+        // Recompute capacity penalty for this site only
+        site_capacity_penalty_[site] = 0.0;
+        for (int t = 0; t < inst_.n_periods; ++t) {
+            int count = 0;
+            for (int o : site_outages_[site]) {
+                int start = outage_starts[o];
+                if (t >= start && t < start + inst_.outage_duration[o]) {
+                    count++;
+                }
+            }
+            int excess = count - inst_.max_outages_per_site[site];
+            if (excess > 0) {
+                site_capacity_penalty_[site] += excess;
+            }
+        }
+
+        // Recompute spacing penalty for this site only
+        site_spacing_penalty_[site] = 0.0;
+        auto& outages = site_outages_[site];
+        if (outages.size() >= 2) {
+            std::sort(outages.begin(), outages.end(),
+                      [&](int a, int b) { return outage_starts[a] < outage_starts[b]; });
+            for (size_t i = 0; i + 1 < outages.size(); ++i) {
+                int o1 = outages[i];
+                int o2 = outages[i + 1];
+                int end1 = outage_starts[o1] + inst_.outage_duration[o1];
+                int gap = outage_starts[o2] - end1;
+                if (gap < inst_.min_spacing_same_site) {
+                    site_spacing_penalty_[site] += (inst_.min_spacing_same_site - gap);
+                }
+            }
+        }
+
+        // Add new site contribution
+        total_penalty_ += site_capacity_penalty_[site] + site_spacing_penalty_[site];
+        return total_penalty_ * penalty_weight;
+    }
+};
 
 }  // namespace nuclear_outage
 }  // namespace cbls

--- a/benchmarks/nuclear-outage/nuclear_hook.h
+++ b/benchmarks/nuclear-outage/nuclear_hook.h
@@ -20,6 +20,8 @@ inline int32_t handle_to_var_id(int32_t handle) {
 /// InnerSolverHook that evaluates production dispatch cost externally.
 /// Reads outage start values from the model, runs merit-order dispatch
 /// across demand scenarios, and writes the expected cost into the objective node.
+///
+/// Uses DispatchEvaluator for allocation-free evaluation (5a/5b/5c/5e).
 class NuclearDispatchHook : public InnerSolverHook {
 public:
     const NuclearInstance& inst;
@@ -30,34 +32,55 @@ public:
     int scenarios_per_move = 50;
 
     NuclearDispatchHook(const NuclearInstance& inst_, const NuclearModel& nm_)
-        : inst(inst_), nm(nm_) {}
+        : inst(inst_), nm(nm_),
+          evaluator_(inst_),
+          starts_(inst_.n_outages, 0),
+          prev_starts_(inst_.n_outages, -1) {}
 
     void solve(Model& model, ViolationManager& /*vm*/,
                const std::vector<int32_t>& /*last_changed_vars*/ = {}) override {
         // 1. Read current outage start values (convert var handles to var IDs)
-        std::vector<int> starts(inst.n_outages);
         for (int o = 0; o < inst.n_outages; ++o) {
             int32_t vid = handle_to_var_id(nm.s[o]);
-            starts[o] = static_cast<int>(std::round(model.var(vid).value));
+            starts_[o] = static_cast<int>(std::round(model.var(vid).value));
         }
 
         // 2. Compute expected dispatch cost with rotating scenario window
         int n_sc = std::min(scenarios_per_move, inst.n_scenarios);
         int offset = scenario_offset_ % std::max(1, inst.n_scenarios - n_sc + 1);
-        double cost = expected_cost(inst, starts, n_sc, offset);
+        double cost = evaluator_.expected_cost(starts_, n_sc, offset);
         scenario_offset_ += n_sc;
 
         // 3. Add resource violation penalty
-        cost += resource_violation_penalty(inst, starts);
+        // 5e: detect which outage changed for delta penalty
+        int changed = find_changed_outage();
+        cost += evaluator_.resource_penalty(starts_, 1e6, changed);
 
         // 4. Write cost into the objective constant node
-        // Update both value and const_value so full_evaluate won't reset it
         model.node_mut(nm.objective_node).value = cost;
         model.node_mut(nm.objective_node).const_value = cost;
+
+        // Save starts for next delta comparison
+        prev_starts_ = starts_;
     }
 
 private:
+    DispatchEvaluator evaluator_;
+    std::vector<int> starts_;
+    std::vector<int> prev_starts_;
     int scenario_offset_ = 0;
+
+    /// Find which outage changed (returns -1 if none or multiple changed).
+    int find_changed_outage() const {
+        int changed = -1;
+        for (int o = 0; o < inst.n_outages; ++o) {
+            if (starts_[o] != prev_starts_[o]) {
+                if (changed >= 0) return -1;  // multiple changed → full recompute
+                changed = o;
+            }
+        }
+        return changed;
+    }
 };
 
 }  // namespace nuclear_outage

--- a/tests/test_nuclear_outage.cpp
+++ b/tests/test_nuclear_outage.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <cbls/cbls.h>
 #include "benchmarks/nuclear-outage/data.h"
 #include "benchmarks/nuclear-outage/dispatch.h"
@@ -121,6 +122,46 @@ TEST_CASE("Resource violation penalty - site spacing", "[nuclear]") {
     starts[1] = 14;
     double penalty2 = resource_violation_penalty(inst, starts);
     REQUIRE(penalty2 < penalty);
+}
+
+TEST_CASE("DispatchEvaluator matches free functions", "[nuclear]") {
+    auto inst = load_mini();
+
+    // Several different outage schedules to test
+    std::vector<std::vector<int>> schedules = {
+        {1, 5, 10, 1, 8, 15, 20, 1, 12, 25},  // earliest starts
+        {30, 35, 40, 28, 33, 38, 42, 30, 36, 42},  // latest starts
+        {15, 20, 25, 14, 20, 26, 30, 15, 24, 33},  // mid-range
+        std::vector<int>(10, 5),  // all at period 5 (causes violations)
+    };
+
+    DispatchEvaluator eval(inst);
+
+    for (auto& starts : schedules) {
+        // Dispatch cost should match
+        double ref_cost = expected_cost(inst, starts, 10, 0);
+        double eval_cost = eval.expected_cost(starts, 10, 0);
+        REQUIRE(eval_cost == Catch::Approx(ref_cost).epsilon(1e-10));
+
+        // Full resource penalty should match
+        double ref_pen = resource_violation_penalty(inst, starts);
+        double eval_pen = eval.resource_penalty(starts, 1e6, -1);
+        REQUIRE(eval_pen == Catch::Approx(ref_pen).epsilon(1e-10));
+    }
+
+    // Test delta resource penalty: change one outage and verify
+    auto starts = schedules[0];
+    eval.resource_penalty(starts, 1e6, -1);  // full compute to initialize
+
+    starts[3] = 10;  // change outage 3
+    double ref_pen = resource_violation_penalty(inst, starts);
+    double delta_pen = eval.resource_penalty(starts, 1e6, 3);
+    REQUIRE(delta_pen == Catch::Approx(ref_pen).epsilon(1e-10));
+
+    starts[7] = 20;  // change outage 7
+    ref_pen = resource_violation_penalty(inst, starts);
+    delta_pen = eval.resource_penalty(starts, 1e6, 7);
+    REQUIRE(delta_pen == Catch::Approx(ref_pen).epsilon(1e-10));
 }
 
 TEST_CASE("Nuclear outage solver finds feasible solution", "[nuclear]") {


### PR DESCRIPTION
## Summary
- Add `DispatchEvaluator` class with pre-allocated scratch buffers, eliminating all heap allocation from the hot path
- Flatten availability matrix from `vector<vector<bool>>` to contiguous `vector<uint8_t>` with `memset` reset
- Cache merit order at construction (fuel costs never change)
- Delta resource penalty: detect which outage changed, only recompute that site's penalty

## Results

| Instance | Before | After | Speedup |
|----------|-------:|------:|--------:|
| mini | 719k iters/sec | 1,142k iters/sec | **1.59x** |
| small | 111k iters/sec | 167k iters/sec | **1.51x** |

Objectives unchanged (correctness preserved). New regression test verifies `DispatchEvaluator` matches original free functions exactly, including delta penalty path.

## Test plan
- [x] `ctest --test-dir build` — all 147 tests pass
- [x] New test: `DispatchEvaluator matches free functions` — validates dispatch cost, full penalty, and delta penalty against reference implementations
- [x] Benchmark produces identical objectives to baseline
- [x] All other benchmarks (UC-CHPED, bunker-eca, pharma-GLSP) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)