### PR TITLE
Add multi-threading with opportunistic and deterministic modes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -805,13 +805,35 @@ arguments, class fields, and local constants. See the
 
 ### Multi-threading
 
-The core solver (`solve()`) is single-threaded. `ParallelSearch` launches N
-independent threads, each creating its own `Model` via a user-provided
+The core solver (`solve()`) is single-threaded. `ParallelSearch` provides
+two modes for multi-threaded search:
+
+**Opportunistic mode** (default): Launches N independent threads (default:
+`hardware_concurrency()`), each creating its own `Model` via a user-provided
 factory function and calling `solve()` with staggered seeds
 (`seed + thread_index`). Only the `SolutionPool` is shared
 (mutex-protected). There is no shared state during search — thread safety is
 achieved by isolation. No OpenMP, no work-stealing, no parallel evaluation
 of the DAG.
+
+**Deterministic epoch-sync mode** (`ParallelConfig::deterministic = true`):
+Threads run in synchronized epochs of fixed iteration count (no wall-clock
+dependency within epochs):
+
+1. All threads start from the same initial state (or elite pool states)
+2. Each thread runs exactly `epoch_iterations` SA iterations using
+   `SearchConfig::max_iterations`
+3. All threads finish the epoch before proceeding
+4. Results collected into `SolutionPool`, top-K elite solutions extracted
+5. Threads restart from elite solutions with fresh temperature
+6. Repeat for `max_epochs` epochs (no wall-clock dependency)
+
+Thread seeding: `base_seed + epoch * n_threads + thread_id` — deterministic
+given the same seed, thread count, and epoch iteration count.
+
+`ParallelSearch::solve()` accepts factory functions for hooks and LNS
+objects (since these are stateful and per-model). Each thread creates its
+own instances via the factories.
 
 ### Determinism
 
@@ -822,10 +844,25 @@ the `seed` parameter. Unordered containers (`unordered_set` in
 membership/lookup — iteration order does not affect results because
 recomputation follows topological order.
 
-**Wall-clock caveat:** `std::chrono::steady_clock` determines when to stop
-FJ and SA. Different machine speeds produce different iteration counts and
-therefore different solutions. Same seed + same hardware + same load =
-reproducible results.
+**Wall-clock caveat:** In opportunistic mode, `std::chrono::steady_clock`
+determines when to stop FJ and SA. Different machine speeds produce
+different iteration counts and therefore different solutions. Same seed +
+same hardware + same load = reproducible results.
+
+**Deterministic mode** eliminates the wall-clock caveat: same seed + same
+`n_threads` + same `epoch_iterations` + same `max_epochs` = identical
+result on any machine. No wall-clock is consulted during deterministic
+execution. The `SearchConfig::max_iterations` field controls
+iteration-count-based stopping (0 = unlimited, use time_limit).
+
+### CLI flags
+
+```
+--threads N           Number of threads (0 = auto-detect, default: 1)
+--deterministic       Enable deterministic epoch-sync mode
+--epoch-iters INT     Iterations per epoch in deterministic mode (default: 5000)
+--max-epochs INT      Number of epochs in deterministic mode (default: 10)
+```
 
 ---
 

--- a/include/cbls/pool.h
+++ b/include/cbls/pool.h
@@ -2,6 +2,8 @@
 
 #include "model.h"
 #include "search.h"
+#include "inner_solver.h"
+#include "lns.h"
 #include "rng.h"
 #include <limits>
 #include <mutex>
@@ -23,6 +25,7 @@ public:
 
     bool submit(const Solution& sol);
     std::optional<Solution> best() const;
+    std::vector<Solution> top_k(int k) const;
     std::optional<Solution> get_restart_point(RNG& rng) const;
     size_t size() const;
 
@@ -32,15 +35,56 @@ private:
     mutable std::mutex mutex_;
 };
 
+struct ParallelConfig {
+    int n_threads = 0;               // 0 = hardware_concurrency()
+    bool deterministic = false;      // epoch-sync mode
+    int64_t epoch_iterations = 5000; // iterations per epoch
+    int max_epochs = 10;             // number of epochs in deterministic mode
+    int elite_pool_size = 4;         // top solutions to share between epochs
+};
+
 class ParallelSearch {
 public:
-    explicit ParallelSearch(int n_threads = 4);
+    explicit ParallelSearch(int n_threads = 0);
 
+    // Simple portfolio solve (backward-compatible)
     SearchResult solve(std::function<Model()> model_factory,
                        double time_limit = 10.0, uint64_t seed = 42);
 
+    // Full-featured solve with hooks, LNS, config, and parallel config
+    SearchResult solve(
+        std::function<Model()> model_factory,
+        double time_limit,
+        uint64_t seed,
+        const SearchConfig& config,
+        std::function<InnerSolverHook*(Model&)> hook_factory,
+        std::function<LNS*()> lns_factory,
+        SolveCallback* callback,
+        const ParallelConfig& par_config);
+
 private:
     int n_threads_;
+
+    int effective_threads(const ParallelConfig& pc) const;
+
+    SearchResult solve_portfolio(
+        std::function<Model()>& model_factory,
+        double time_limit, uint64_t seed,
+        const SearchConfig& config,
+        std::function<InnerSolverHook*(Model&)>& hook_factory,
+        std::function<LNS*()>& lns_factory,
+        SolveCallback* callback,
+        int n_threads);
+
+    SearchResult solve_deterministic(
+        std::function<Model()>& model_factory,
+        uint64_t seed,
+        const SearchConfig& config,
+        std::function<InnerSolverHook*(Model&)>& hook_factory,
+        std::function<LNS*()>& lns_factory,
+        SolveCallback* callback,
+        const ParallelConfig& par_config,
+        int n_threads);
 };
 
 }  // namespace cbls

--- a/include/cbls/search.h
+++ b/include/cbls/search.h
@@ -16,6 +16,9 @@ struct SearchConfig {
     int hook_frequency = 10;
     double fj_time_fraction = 0.2;
     bool skip_init = false;
+    int64_t max_iterations = 0;  // 0 = unlimited (use time_limit)
+    bool use_fj = true;
+    int lns_interval = 3;
 };
 
 struct SearchResult {

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -288,7 +288,33 @@ NB_MODULE(_cbls_core, m) {
         .def(nb::init<int>(), nb::arg("capacity") = 10)
         .def("submit", &SolutionPool::submit)
         .def("best", &SolutionPool::best)
+        .def("top_k", &SolutionPool::top_k)
         .def("size", &SolutionPool::size);
+
+    // ParallelConfig
+    nb::class_<ParallelConfig>(m, "ParallelConfig")
+        .def(nb::init<>())
+        .def_rw("n_threads", &ParallelConfig::n_threads)
+        .def_rw("deterministic", &ParallelConfig::deterministic)
+        .def_rw("epoch_iterations", &ParallelConfig::epoch_iterations)
+        .def_rw("max_epochs", &ParallelConfig::max_epochs)
+        .def_rw("elite_pool_size", &ParallelConfig::elite_pool_size);
+
+    // ParallelSearch
+    nb::class_<ParallelSearch>(m, "ParallelSearch")
+        .def(nb::init<int>(), nb::arg("n_threads") = 0)
+        .def("solve", static_cast<SearchResult(ParallelSearch::*)(
+            std::function<Model()>, double, uint64_t)>(&ParallelSearch::solve),
+            nb::arg("model_factory"), nb::arg("time_limit") = 10.0,
+            nb::arg("seed") = 42)
+        .def("solve_parallel", static_cast<SearchResult(ParallelSearch::*)(
+            std::function<Model()>, double, uint64_t, const SearchConfig&,
+            std::function<InnerSolverHook*(Model&)>, std::function<LNS*()>,
+            SolveCallback*, const ParallelConfig&)>(&ParallelSearch::solve),
+            nb::arg("model_factory"), nb::arg("time_limit") = 10.0,
+            nb::arg("seed") = 42, nb::arg("config") = SearchConfig{},
+            nb::arg("hook_factory") = nullptr, nb::arg("lns_factory") = nullptr,
+            nb::arg("callback") = nullptr, nb::arg("par_config") = ParallelConfig{});
 
     // Free functions
     m.def("full_evaluate", &full_evaluate);
@@ -321,7 +347,10 @@ NB_MODULE(_cbls_core, m) {
         .def_rw("reheat_interval", &SearchConfig::reheat_interval)
         .def_rw("hook_frequency", &SearchConfig::hook_frequency)
         .def_rw("fj_time_fraction", &SearchConfig::fj_time_fraction)
-        .def_rw("skip_init", &SearchConfig::skip_init);
+        .def_rw("skip_init", &SearchConfig::skip_init)
+        .def_rw("max_iterations", &SearchConfig::max_iterations)
+        .def_rw("use_fj", &SearchConfig::use_fj)
+        .def_rw("lns_interval", &SearchConfig::lns_interval);
 
     // SolveProgress
     nb::class_<SolveProgress>(m, "SolveProgress")

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -3,6 +3,7 @@
 #include "cbls/formatter.h"
 #include <iostream>
 #include <string>
+#include <thread>
 
 using namespace cbls;
 
@@ -26,6 +27,10 @@ Options:
   --reheat-interval INT SA reheat interval in iterations (default: 5000)
   --hook-frequency INT  Run hook every N discrete acceptances (default: 10)
   --fj-time-fraction F  Fraction of time limit for FJ init (default: 0.2)
+  --threads N           Number of threads (0 = auto-detect, default: 1)
+  --deterministic       Enable deterministic epoch-sync parallel mode
+  --epoch-iters INT     Iterations per epoch in deterministic mode (default: 5000)
+  --max-epochs INT      Number of epochs in deterministic mode (default: 10)
   --format human|jsonl  Output format (default: human)
   --quiet               Suppress progress, print only final result
   --help                Show this help message
@@ -44,6 +49,10 @@ int main(int argc, char* argv[]) {
     SearchConfig config;
     std::string format = "human";
     bool quiet = false;
+    int n_threads = 1;
+    bool deterministic = false;
+    int64_t epoch_iters = 5000;
+    int max_epochs = 10;
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
@@ -59,10 +68,12 @@ int main(int argc, char* argv[]) {
             seed = std::stoull(argv[++i]);
         } else if (arg == "--no-fj") {
             use_fj = false;
+            config.use_fj = false;
         } else if (arg == "--lns" && i + 1 < argc) {
             lns_fraction = std::stod(argv[++i]);
         } else if (arg == "--lns-interval" && i + 1 < argc) {
             lns_interval = std::stoi(argv[++i]);
+            config.lns_interval = lns_interval;
         } else if (arg == "--intensify") {
             use_intensify = true;
         } else if (arg == "--cooling-rate" && i + 1 < argc) {
@@ -79,6 +90,14 @@ int main(int argc, char* argv[]) {
                 std::cerr << "Error: --format must be 'human' or 'jsonl'\n";
                 return 1;
             }
+        } else if (arg == "--threads" && i + 1 < argc) {
+            n_threads = std::stoi(argv[++i]);
+        } else if (arg == "--deterministic") {
+            deterministic = true;
+        } else if (arg == "--epoch-iters" && i + 1 < argc) {
+            epoch_iters = std::stoll(argv[++i]);
+        } else if (arg == "--max-epochs" && i + 1 < argc) {
+            max_epochs = std::stoi(argv[++i]);
         } else if (arg == "--quiet") {
             quiet = true;
         } else if (arg[0] == '-') {
@@ -102,13 +121,6 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    // Set up optional components
-    FloatIntensifyHook intensify_hook;
-    InnerSolverHook* hook = use_intensify ? &intensify_hook : nullptr;
-
-    LNS lns_obj(lns_fraction);
-    LNS* lns_ptr = lns_fraction > 0.0 ? &lns_obj : nullptr;
-
     // Set up formatter
     HumanFormatter human_fmt(std::cout);
     JsonlFormatter jsonl_fmt(std::cout);
@@ -124,8 +136,56 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    auto result = solve(model, time_limit, seed, use_fj,
-                        hook, lns_ptr, lns_interval, callback, config);
+    // Determine effective thread count
+    int effective_threads = n_threads;
+    if (effective_threads == 0) {
+        effective_threads = static_cast<int>(std::thread::hardware_concurrency());
+        if (effective_threads < 1) effective_threads = 1;
+    }
+
+    SearchResult result;
+
+    if (effective_threads > 1 || deterministic) {
+        // Parallel mode: use ParallelSearch
+        // Capture model_path for the factory (model is loaded once, factory re-loads)
+        auto model_factory = [&model_path]() {
+            return load_model(model_path);
+        };
+
+        std::function<InnerSolverHook*(Model&)> hook_factory;
+        if (use_intensify) {
+            hook_factory = [](Model&) -> InnerSolverHook* {
+                return new FloatIntensifyHook();
+            };
+        }
+
+        std::function<LNS*()> lns_factory;
+        if (lns_fraction > 0.0) {
+            lns_factory = [lns_fraction]() -> LNS* {
+                return new LNS(lns_fraction);
+            };
+        }
+
+        ParallelConfig par_config;
+        par_config.n_threads = effective_threads;
+        par_config.deterministic = deterministic;
+        par_config.epoch_iterations = epoch_iters;
+        par_config.max_epochs = max_epochs;
+
+        ParallelSearch ps(effective_threads);
+        result = ps.solve(model_factory, time_limit, seed, config,
+                          hook_factory, lns_factory, callback, par_config);
+    } else {
+        // Single-thread mode: use solve() directly
+        FloatIntensifyHook intensify_hook;
+        InnerSolverHook* hook = use_intensify ? &intensify_hook : nullptr;
+
+        LNS lns_obj(lns_fraction);
+        LNS* lns_ptr = lns_fraction > 0.0 ? &lns_obj : nullptr;
+
+        result = solve(model, time_limit, seed, use_fj,
+                       hook, lns_ptr, lns_interval, callback, config);
+    }
 
     if (format == "human") {
         human_fmt.print_result(result, model);

--- a/src/pool.cpp
+++ b/src/pool.cpp
@@ -1,15 +1,20 @@
 #include "cbls/pool.h"
+#include "cbls/dag_ops.h"
 #include <thread>
 #include <algorithm>
+#include <chrono>
+#include <limits>
+#include <memory>
 
 namespace cbls {
+
+// --- SolutionPool ---
 
 SolutionPool::SolutionPool(int capacity) : capacity_(capacity) {}
 
 bool SolutionPool::submit(const Solution& sol) {
     std::lock_guard<std::mutex> lock(mutex_);
     solutions_.push_back(sol);
-    // Sort: feasible first, then by objective ascending
     std::sort(solutions_.begin(), solutions_.end(),
               [](const Solution& a, const Solution& b) {
                   if (a.feasible != b.feasible) return a.feasible > b.feasible;
@@ -27,6 +32,12 @@ std::optional<Solution> SolutionPool::best() const {
     return solutions_[0];
 }
 
+std::vector<Solution> SolutionPool::top_k(int k) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    int n = std::min(k, static_cast<int>(solutions_.size()));
+    return std::vector<Solution>(solutions_.begin(), solutions_.begin() + n);
+}
+
 std::optional<Solution> SolutionPool::get_restart_point(RNG& rng) const {
     std::lock_guard<std::mutex> lock(mutex_);
     if (solutions_.empty()) return std::nullopt;
@@ -40,19 +51,84 @@ size_t SolutionPool::size() const {
     return solutions_.size();
 }
 
+// --- ParallelSearch ---
+
 ParallelSearch::ParallelSearch(int n_threads) : n_threads_(n_threads) {}
 
+int ParallelSearch::effective_threads(const ParallelConfig& pc) const {
+    int n = pc.n_threads > 0 ? pc.n_threads : n_threads_;
+    if (n <= 0) {
+        n = static_cast<int>(std::thread::hardware_concurrency());
+    }
+    return std::max(1, n);
+}
+
+// Backward-compatible simple solve
 SearchResult ParallelSearch::solve(std::function<Model()> model_factory,
                                     double time_limit, uint64_t seed) {
+    ParallelConfig pc;
+    pc.n_threads = n_threads_;
+    std::function<InnerSolverHook*(Model&)> no_hook;
+    std::function<LNS*()> no_lns;
+    int n = effective_threads(pc);
+    return solve_portfolio(model_factory, time_limit, seed, {}, no_hook, no_lns, nullptr, n);
+}
+
+// Full-featured solve
+SearchResult ParallelSearch::solve(
+    std::function<Model()> model_factory,
+    double time_limit,
+    uint64_t seed,
+    const SearchConfig& config,
+    std::function<InnerSolverHook*(Model&)> hook_factory,
+    std::function<LNS*()> lns_factory,
+    SolveCallback* callback,
+    const ParallelConfig& par_config) {
+
+    int n = effective_threads(par_config);
+
+    if (par_config.deterministic) {
+        return solve_deterministic(model_factory, seed, config,
+                                   hook_factory, lns_factory, callback, par_config, n);
+    } else {
+        return solve_portfolio(model_factory, time_limit, seed, config,
+                               hook_factory, lns_factory, callback, n);
+    }
+}
+
+// --- Portfolio (opportunistic) mode ---
+
+SearchResult ParallelSearch::solve_portfolio(
+    std::function<Model()>& model_factory,
+    double time_limit, uint64_t seed,
+    const SearchConfig& config,
+    std::function<InnerSolverHook*(Model&)>& hook_factory,
+    std::function<LNS*()>& lns_factory,
+    SolveCallback* callback,
+    int n_threads) {
+
     SolutionPool pool;
-    std::vector<SearchResult> results(n_threads_);
+    std::vector<SearchResult> results(n_threads);
     std::vector<std::thread> threads;
 
-    for (int i = 0; i < n_threads_; ++i) {
+    for (int i = 0; i < n_threads; ++i) {
         threads.emplace_back([&, i]() {
             try {
                 Model m = model_factory();
-                results[i] = cbls::solve(m, time_limit, seed + i);
+
+                std::unique_ptr<InnerSolverHook> hook;
+                if (hook_factory) hook.reset(hook_factory(m));
+
+                std::unique_ptr<LNS> lns;
+                if (lns_factory) lns.reset(lns_factory());
+
+                // Only thread 0 gets the callback to avoid interleaved output
+                SolveCallback* cb = (i == 0) ? callback : nullptr;
+
+                results[i] = cbls::solve(m, time_limit, seed + i,
+                                         config.use_fj, hook.get(),
+                                         lns.get(), config.lns_interval,
+                                         cb, config);
 
                 Solution sol;
                 sol.state = results[i].best_state;
@@ -67,12 +143,22 @@ SearchResult ParallelSearch::solve(std::function<Model()> model_factory,
 
     for (auto& t : threads) t.join();
 
+    // Aggregate results
     auto best = pool.best();
     if (best) {
         SearchResult result;
         result.objective = best->objective;
         result.feasible = best->feasible;
         result.best_state = best->state;
+        // Sum iterations and take max time across threads
+        int64_t total_iters = 0;
+        double max_time = 0.0;
+        for (const auto& r : results) {
+            total_iters += r.iterations;
+            max_time = std::max(max_time, r.time_seconds);
+        }
+        result.iterations = total_iters;
+        result.time_seconds = max_time;
         return result;
     }
 
@@ -86,6 +172,112 @@ SearchResult ParallelSearch::solve(std::function<Model()> model_factory,
         }
     }
     return best_result;
+}
+
+// --- Deterministic epoch-sync mode ---
+
+SearchResult ParallelSearch::solve_deterministic(
+    std::function<Model()>& model_factory,
+    uint64_t seed,
+    const SearchConfig& config,
+    std::function<InnerSolverHook*(Model&)>& hook_factory,
+    std::function<LNS*()>& lns_factory,
+    SolveCallback* callback,
+    const ParallelConfig& par_config,
+    int n_threads) {
+
+    auto start = std::chrono::steady_clock::now();
+
+    int elite_k = std::max(1, par_config.elite_pool_size);
+    int64_t epoch_iters = std::max(int64_t(1), par_config.epoch_iterations);
+    int max_epochs = std::max(1, par_config.max_epochs);
+
+    // Each thread owns its model; initialize from factory
+    std::vector<Model> models(n_threads);
+    for (int i = 0; i < n_threads; ++i) {
+        models[i] = model_factory();
+    }
+
+    // Per-thread hooks and LNS
+    std::vector<std::unique_ptr<InnerSolverHook>> hooks(n_threads);
+    std::vector<std::unique_ptr<LNS>> lns_objs(n_threads);
+    for (int i = 0; i < n_threads; ++i) {
+        if (hook_factory) hooks[i].reset(hook_factory(models[i]));
+        if (lns_factory) lns_objs[i].reset(lns_factory());
+    }
+
+    // Global best tracking
+    SolutionPool pool(elite_k);
+    SearchResult global_best;
+    int64_t total_iterations = 0;
+
+    // Per-thread results for each epoch
+    std::vector<SearchResult> epoch_results(n_threads);
+
+    // In deterministic mode, epochs stop by iteration count, not wall-clock.
+    // Use a huge time_limit so wall-clock never cuts an epoch short.
+    const double epoch_time_limit = std::numeric_limits<double>::max();
+
+    for (int epoch = 0; epoch < max_epochs; ++epoch) {
+        // Configure per-epoch search: iteration-limited, no FJ after first epoch
+        SearchConfig epoch_config = config;
+        epoch_config.max_iterations = epoch_iters;
+        if (epoch > 0) {
+            epoch_config.skip_init = true;
+        }
+
+        // Launch threads for this epoch
+        std::vector<std::thread> threads;
+        for (int i = 0; i < n_threads; ++i) {
+            threads.emplace_back([&, i, epoch]() {
+                // Deterministic seed: base_seed + epoch * n_threads + thread_id
+                uint64_t thread_seed = seed + static_cast<uint64_t>(epoch) * n_threads + i;
+
+                SolveCallback* cb = (i == 0) ? callback : nullptr;
+
+                epoch_results[i] = cbls::solve(
+                    models[i], epoch_time_limit, thread_seed,
+                    (epoch == 0) && config.use_fj,
+                    hooks[i].get(), lns_objs[i].get(),
+                    config.lns_interval, cb, epoch_config);
+            });
+        }
+
+        for (auto& t : threads) t.join();
+
+        // Collect results into pool
+        for (int i = 0; i < n_threads; ++i) {
+            Solution sol;
+            sol.state = epoch_results[i].best_state;
+            sol.objective = epoch_results[i].objective;
+            sol.feasible = epoch_results[i].feasible;
+            pool.submit(sol);
+            total_iterations += epoch_results[i].iterations;
+        }
+
+        // Redistribute elite solutions to threads for next epoch
+        auto elite = pool.top_k(elite_k);
+        if (!elite.empty()) {
+            for (int i = 0; i < n_threads; ++i) {
+                const auto& sol = elite[i % static_cast<int>(elite.size())];
+                models[i].restore_state(sol.state);
+                full_evaluate(models[i]);
+            }
+        }
+    }
+
+    // Build final result from pool
+    auto best = pool.best();
+    if (best) {
+        global_best.objective = best->objective;
+        global_best.feasible = best->feasible;
+        global_best.best_state = best->state;
+    }
+    global_best.iterations = total_iterations;
+    global_best.time_seconds = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - start).count();
+
+    return global_best;
 }
 
 }  // namespace cbls

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -275,7 +275,9 @@ SearchResult solve(Model& model, double time_limit, uint64_t seed, bool use_fj,
     auto last_callback_time = start;
     constexpr double callback_interval_secs = 1.0;
 
-    while (std::chrono::steady_clock::now() < deadline) {
+    const int64_t max_iters = config.max_iterations;
+    while ((max_iters > 0 ? iteration < max_iters : true) &&
+           std::chrono::steady_clock::now() < deadline) {
         // Select random variable
         int var_idx = static_cast<int>(rng.integers(0, model.num_vars()));
         const auto& var = model.var(var_idx);

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -381,9 +381,9 @@ TEST_CASE("copy_state and restore_state", "[model]") {
     REQUIRE(m.var(vid(y)).value == 7.0);
 }
 
-// ParallelSearch test
-TEST_CASE("ParallelSearch basic", "[pool]") {
-    auto model_factory = []() {
+// Helper: factory for a simple x^2 + y^2 model
+static std::function<Model()> simple_model_factory() {
+    return []() {
         Model m;
         auto x = m.float_var(-5, 5);
         auto y = m.float_var(-5, 5);
@@ -392,9 +392,99 @@ TEST_CASE("ParallelSearch basic", "[pool]") {
         m.close();
         return m;
     };
+}
 
+// ParallelSearch test
+TEST_CASE("ParallelSearch basic", "[pool]") {
     ParallelSearch ps(2);
-    auto result = ps.solve(model_factory, 1.0, 42);
+    auto result = ps.solve(simple_model_factory(), 1.0, 42);
     REQUIRE(result.feasible);
     REQUIRE(result.objective < 5.0);
+}
+
+TEST_CASE("ParallelSearch default threads uses hardware_concurrency", "[pool]") {
+    ParallelSearch ps;  // n_threads=0 -> hardware_concurrency()
+    auto result = ps.solve(simple_model_factory(), 1.0, 42);
+    REQUIRE(result.feasible);
+    REQUIRE(result.objective < 5.0);
+}
+
+TEST_CASE("ParallelSearch with hook and LNS factories", "[pool]") {
+    auto factory = []() {
+        Model m;
+        auto x = m.float_var(0, 10);
+        auto y = m.float_var(0, 10);
+        auto neg1 = m.constant(-1.0);
+        auto five = m.constant(5.0);
+        m.add_constraint(m.sum({five, m.prod(neg1, x), m.prod(neg1, y)}));
+        m.minimize(m.sum({x, y}));
+        m.close();
+        return m;
+    };
+
+    auto hook_factory = [](Model&) -> InnerSolverHook* {
+        return new FloatIntensifyHook();
+    };
+    auto lns_factory = []() -> LNS* {
+        return new LNS(0.3);
+    };
+
+    ParallelSearch ps(2);
+    ParallelConfig pc;
+    pc.n_threads = 2;
+    auto result = ps.solve(factory, 2.0, 42, {}, hook_factory, lns_factory, nullptr, pc);
+    REQUIRE(result.feasible);
+    REQUIRE(result.objective < 15.0);
+}
+
+TEST_CASE("Deterministic mode produces identical results", "[pool][deterministic]") {
+    auto factory = simple_model_factory();
+
+    ParallelConfig pc;
+    pc.n_threads = 2;
+    pc.deterministic = true;
+    pc.epoch_iterations = 5000;
+    pc.max_epochs = 3;
+    pc.elite_pool_size = 2;
+
+    ParallelSearch ps1(2);
+    auto r1 = ps1.solve(factory, 999.0, 42, {}, nullptr, nullptr, nullptr, pc);
+
+    ParallelSearch ps2(2);
+    auto r2 = ps2.solve(factory, 999.0, 42, {}, nullptr, nullptr, nullptr, pc);
+
+    REQUIRE(r1.feasible);
+    REQUIRE(r2.feasible);
+    REQUIRE(r1.objective == r2.objective);
+    REQUIRE(r1.iterations == r2.iterations);
+}
+
+TEST_CASE("max_iterations stops SA by iteration count", "[search]") {
+    Model m;
+    auto x = m.float_var(-5, 5);
+    auto y = m.float_var(-5, 5);
+    auto two = m.constant(2);
+    m.minimize(m.sum({m.pow_expr(x, two), m.pow_expr(y, two)}));
+    m.close();
+
+    SearchConfig config;
+    config.max_iterations = 1000;
+    auto result = solve(m, 60.0, 42, true, nullptr, nullptr, 3, nullptr, config);
+    // Should stop well before the 60s time limit
+    REQUIRE(result.time_seconds < 5.0);
+    REQUIRE(result.iterations <= 1000);
+}
+
+TEST_CASE("SolutionPool top_k", "[pool]") {
+    SolutionPool pool(10);
+    Model::State empty_state;
+    pool.submit({empty_state, 10.0, true});
+    pool.submit({empty_state, 5.0, true});
+    pool.submit({empty_state, 3.0, true});
+    pool.submit({empty_state, 20.0, false});
+
+    auto top2 = pool.top_k(2);
+    REQUIRE(top2.size() == 2);
+    REQUIRE(top2[0].objective == 3.0);
+    REQUIRE(top2[1].objective == 5.0);
 }


### PR DESCRIPTION
## Summary

- **Opportunistic mode** (default): runs `hardware_concurrency()` independent SA threads with staggered seeds, returns best result. Supports hook/LNS factory functions for per-thread instances.
- **Deterministic epoch-sync mode**: threads run fixed `epoch_iterations` per epoch for `max_epochs` epochs, syncing elite solutions between epochs. No wall-clock dependency — same seed + threads + epochs = identical result on any machine.
- **`max_iterations`** added to `SearchConfig` for iteration-count-based stopping (used internally by deterministic mode, also available standalone).
- **CLI flags**: `--threads N`, `--deterministic`, `--epoch-iters`, `--max-epochs`
- **Python bindings**: `ParallelConfig`, `ParallelSearch.solve()` / `solve_parallel()`
- **Docs**: Updated Threading & Determinism section in `architecture.md`

## Test plan

- [x] All 120 existing core tests pass (no regressions)
- [x] New test: `ParallelSearch` with default `hardware_concurrency()` threads
- [x] New test: `ParallelSearch` with hook and LNS factory functions
- [x] New test: deterministic mode produces identical objective and iteration count across two runs
- [x] New test: `max_iterations` stops SA by iteration count (not wall-clock)
- [x] New test: `SolutionPool::top_k` ordering
- [x] Deterministic test verified stable across 5 consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)